### PR TITLE
Remove conditional HashMaps and a footgun

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "pwasm-utils"
-version = "0.19.0"
+name = "casper-wasm-utils"
+version = "0.20.0"
 edition = "2021"
 rust-version = "1.56.1"
 authors = ["Nikolay Volf <nikvolf@gmail.com>", "Sergey Pepyakin <s.pepyakin@gmail.com>"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casper-wasm-utils"
-version = "0.20.0"
+version = "0.1.0"
 edition = "2021"
 rust-version = "1.56.1"
 authors = ["Nikolay Volf <nikvolf@gmail.com>", "Sergey Pepyakin <s.pepyakin@gmail.com>"]

--- a/cli/gas.rs
+++ b/cli/gas.rs
@@ -1,4 +1,4 @@
-use pwasm_utils::{self as utils, logger};
+use casper_wasm_utils::{self as utils, logger};
 use std::env;
 
 fn main() {

--- a/cli/stack_height.rs
+++ b/cli/stack_height.rs
@@ -1,4 +1,4 @@
-use pwasm_utils::{logger, stack_height};
+use casper_wasm_utils::{logger, stack_height};
 use std::env;
 
 fn main() {

--- a/examples/opt_imports.rs
+++ b/examples/opt_imports.rs
@@ -8,7 +8,7 @@ fn main() {
     }
 
     // Loading module
-    let mut module = pwasm_utils::Module::from_elements(
+    let mut module = casper_wasm_utils::Module::from_elements(
         &parity_wasm::deserialize_file(&args[1]).expect("Module deserialization to succeed"),
     )
     .expect("Failed to parse parity-wasm format");

--- a/src/gas/validation.rs
+++ b/src/gas/validation.rs
@@ -15,10 +15,7 @@ use crate::{
 };
 use parity_wasm::elements::{FuncBody, Instruction};
 
-#[cfg(not(features = "std"))]
 use crate::std::collections::BTreeMap as Map;
-#[cfg(features = "std")]
-use crate::std::collections::HashMap as Map;
 
 /// An ID for a node in a ControlFlowGraph.
 type NodeId = usize;

--- a/src/optimizer.rs
+++ b/src/optimizer.rs
@@ -1,7 +1,5 @@
 #[cfg(not(features = "std"))]
 use crate::std::collections::BTreeSet as Set;
-#[cfg(features = "std")]
-use crate::std::collections::HashSet as Set;
 use crate::std::{mem, vec::Vec};
 
 use crate::symbols::{expand_symbols, push_code_symbols, resolve_function, Symbol};

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -1,7 +1,4 @@
-#[cfg(not(features = "std"))]
 use crate::std::collections::BTreeMap as Map;
-#[cfg(features = "std")]
-use crate::std::collections::HashMap as Map;
 
 use crate::std::{num::NonZeroU32, str::FromStr};
 use parity_wasm::elements::Instruction;

--- a/src/stack_height/thunk.rs
+++ b/src/stack_height/thunk.rs
@@ -1,4 +1,4 @@
-use crate::std::collections::BTreeMap as Map;
+use crate::std::collections::{BTreeMap as Map, BTreeSet as Set};
 use crate::std::vec::Vec;
 
 use parity_wasm::{
@@ -44,10 +44,12 @@ pub(crate) fn generate_thunks(
         // Replacement map is at least export section size.
         let mut replacement_map: Map<u32, Thunk> = Map::new();
 
-        for func_idx in exported_func_indices
+        let set_of_func_idx: Set<_> = exported_func_indices
             .chain(table_func_indices)
-            .chain(start_func_idx.into_iter())
-        {
+            .chain(start_func_idx)
+            .collect();
+
+        for func_idx in set_of_func_idx {
             let callee_stack_cost = ctx
                 .stack_cost(func_idx)
                 .ok_or_else(|| Error(format!("function with idx {} isn't found", func_idx)))?;

--- a/src/stack_height/thunk.rs
+++ b/src/stack_height/thunk.rs
@@ -1,7 +1,4 @@
-#[cfg(not(features = "std"))]
 use crate::std::collections::BTreeMap as Map;
-#[cfg(features = "std")]
-use crate::std::collections::HashMap as Map;
 use crate::std::vec::Vec;
 
 use parity_wasm::{

--- a/src/symbols.rs
+++ b/src/symbols.rs
@@ -1,7 +1,4 @@
-#[cfg(not(features = "std"))]
 use crate::std::collections::BTreeSet as Set;
-#[cfg(features = "std")]
-use crate::std::collections::HashSet as Set;
 use crate::std::vec::Vec;
 
 use log::trace;

--- a/tests/diff.rs
+++ b/tests/diff.rs
@@ -1,5 +1,6 @@
+use casper_wasm_utils as utils;
 use parity_wasm::elements;
-use pwasm_utils as utils;
+
 use std::{
     fs,
     io::{self, Read, Write},


### PR DESCRIPTION
- This PR removes potentially dangerous conditional HashMaps which could lead to generating non-deterministic Wasm bytes due to random order. 
- This also adds a set of function indices that are going to be replaced by thunks into an explicit set to avoid repeated replacement of elements in a "replacement map". 