### PR TITLE
Update parity-wasm crate to support wasmi 0.13.2.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ required-features = ["cli"]
 [dependencies]
 byteorder = { version = "1", default-features = false }
 log = { version = "0.4", default-features = false }
-parity-wasm = { version = "0.42", default-features = false }
+parity-wasm = { version = "0.45", default-features = false }
 
 # Dependencies only used by the binaries
 clap = { version = "2", optional = true }


### PR DESCRIPTION
Update `parity-wasm` crate to support wasmi 0.13.2 upgrade in the node - casper-network/casper-node#3766