### PR TITLE
Update to 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,13 @@ All notable changes to this project will be documented in this file.  The format
 
 ## [Unreleased]
 
+## [2.0.0] - 2023-06-14
+
+
+
 ## [1.1.0] - 2023-06-13
+
+
 
 ### Changed
 * Update `parity-wasm` to 0.45.0
@@ -33,6 +39,7 @@ All notable changes to this project will be documented in this file.  The format
 
 
 [Keep a Changelog]: https://keepachangelog.com/en/1.0.0
-[unreleased]: https://github.com/casper-network/casper-wasm-utils/compare/v1.1.0...master
+[unreleased]: https://github.com/casper-network/casper-wasm-utils/compare/v2.0.0...master
+[1.1.0]: https://github.com/casper-network/casper-wasm-utils/compare/v1.1.0...v2.0.0
 [1.1.0]: https://github.com/casper-network/casper-wasm-utils/compare/c20633c...v1.1.0
 [0.19.0]: https://github.com/paritytech/wasm-utils

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casper-wasm-utils"
-version = "1.1.0"
+version = "2.0.0"
 edition = "2021"
 rust-version = "1.56.1"
 authors = ["Nikolay Volf <nikvolf@gmail.com>", "Sergey Pepyakin <s.pepyakin@gmail.com>", "Félix Daudré-Vignier <felix@casperlabs.io>", "Michał Papierski <michal@casperlabs.io>"]


### PR DESCRIPTION
The previous release (1.1.0) was yanked due to parity-wasm 0.43 vs 0.45 incompatibility. Bumping to a major release solves the issue for consumers using both parity-wasm-utils 0.43 and casper-wasm-utils