### PR TITLE
Update to casper wasm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ All notable changes to this project will be documented in this file.  The format
 
 ## [Unreleased]
 
+### Changed
+* Move from `parity-wasm` to `casper-wasm`.
+* Don't re-export `parity-wasm` anymore to avoid further breaking changes.
+
 ## [2.0.0] - 2023-06-14
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ required-features = ["cli"]
 [dependencies]
 byteorder = { version = "1", default-features = false }
 log = { version = "0.4", default-features = false }
-parity-wasm = { version = "0.45", default-features = false }
+casper-wasm = { version = "0.46", default-features = false }
 
 # Dependencies only used by the binaries
 clap = { version = "2", optional = true }
@@ -42,7 +42,7 @@ wabt = "0.10"
 
 [features]
 default = ["std"]
-std = ["parity-wasm/std", "log/std", "byteorder/std"]
+std = ["casper-wasm/std", "log/std", "byteorder/std"]
 cli = [
   "std",
   "glob",
@@ -50,4 +50,4 @@ cli = [
   "env_logger",
   "lazy_static",
 ]
-sign_ext = ["parity-wasm/sign_ext"]
+sign_ext = ["casper-wasm/sign_ext"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "casper-wasm-utils"
-version = "2.0.0"
+version = "3.0.0"
 edition = "2021"
 rust-version = "1.56.1"
 authors = ["Nikolay Volf <nikvolf@gmail.com>", "Sergey Pepyakin <s.pepyakin@gmail.com>", "Félix Daudré-Vignier <felix@casperlabs.io>", "Michał Papierski <michal@casperlabs.io>"]

--- a/cli/gas.rs
+++ b/cli/gas.rs
@@ -12,10 +12,10 @@ fn main() {
 
     // Loading module
     let module =
-        parity_wasm::deserialize_file(&args[1]).expect("Module deserialization to succeed");
+        casper_wasm::deserialize_file(&args[1]).expect("Module deserialization to succeed");
 
     let result = utils::inject_gas_counter(module, &utils::rules::Set::default(), "env")
         .expect("Failed to inject gas. Some forbidden opcodes?");
 
-    parity_wasm::serialize_to_file(&args[2], result).expect("Module serialization to succeed")
+    casper_wasm::serialize_to_file(&args[2], result).expect("Module serialization to succeed")
 }

--- a/cli/stack_height.rs
+++ b/cli/stack_height.rs
@@ -15,10 +15,10 @@ fn main() {
 
     // Loading module
     let module =
-        parity_wasm::deserialize_file(input_file).expect("Module deserialization to succeed");
+        casper_wasm::deserialize_file(input_file).expect("Module deserialization to succeed");
 
     let result =
         stack_height::inject_limiter(module, 1024).expect("Failed to inject stack height counter");
 
-    parity_wasm::serialize_to_file(output_file, result).expect("Module serialization to succeed")
+    casper_wasm::serialize_to_file(output_file, result).expect("Module serialization to succeed")
 }

--- a/src/ext.rs
+++ b/src/ext.rs
@@ -1,7 +1,7 @@
 use crate::std::{borrow::ToOwned, string::String, vec::Vec};
 
 use byteorder::{ByteOrder, LittleEndian};
-use parity_wasm::{builder, elements};
+use casper_wasm::{builder, elements};
 
 use crate::optimizer::{export_section, import_section};
 
@@ -12,7 +12,7 @@ pub fn update_call_index(
     original_imports: usize,
     inserts: &[Insertion],
 ) {
-    use parity_wasm::elements::Instruction::*;
+    use casper_wasm::elements::Instruction::*;
     for instruction in instructions.elements_mut().iter_mut() {
         if let Call(call_index) = instruction {
             if let Some(pos) = inserts.iter().position(|x| x.1 == *call_index) {

--- a/src/gas.rs
+++ b/src/gas.rs
@@ -10,10 +10,10 @@ mod validation;
 use crate::std::{cmp::min, mem, vec::Vec};
 
 use crate::rules::Rules;
-use parity_wasm::{builder, elements, elements::ValueType};
+use casper_wasm::{builder, elements, elements::ValueType};
 
 pub fn update_call_index(instructions: &mut elements::Instructions, inserted_index: u32) {
-    use parity_wasm::elements::Instruction::*;
+    use casper_wasm::elements::Instruction::*;
     for instruction in instructions.elements_mut().iter_mut() {
         if let Call(call_index) = instruction {
             if *call_index >= inserted_index {
@@ -225,7 +225,7 @@ impl Counter {
 }
 
 fn inject_grow_counter(instructions: &mut elements::Instructions, grow_counter_func: u32) -> usize {
-    use parity_wasm::elements::Instruction::*;
+    use casper_wasm::elements::Instruction::*;
     let mut counter = 0;
     for instruction in instructions.elements_mut() {
         if let GrowMemory(_) = *instruction {
@@ -242,7 +242,7 @@ fn add_grow_counter<R: Rules>(
     gas_func: u32,
 ) -> elements::Module {
     use crate::rules::MemoryGrowCost;
-    use parity_wasm::elements::Instruction::*;
+    use casper_wasm::elements::Instruction::*;
 
     let cost = match rules.memory_grow_cost() {
         None => return module,
@@ -278,7 +278,7 @@ pub(crate) fn determine_metered_blocks<R: Rules>(
     instructions: &elements::Instructions,
     rules: &R,
 ) -> Result<Vec<MeteredBlock>, ()> {
-    use parity_wasm::elements::Instruction::*;
+    use casper_wasm::elements::Instruction::*;
 
     let mut counter = Counter::new();
 
@@ -365,7 +365,7 @@ fn insert_metering_calls(
     blocks: Vec<MeteredBlock>,
     gas_func: u32,
 ) -> Result<(), ()> {
-    use parity_wasm::elements::Instruction::*;
+    use casper_wasm::elements::Instruction::*;
 
     // To do this in linear time, construct a new vector of instructions, copying over old
     // instructions one by one and injecting new ones as required.
@@ -532,7 +532,7 @@ pub fn inject_gas_counter<R: Rules>(
 mod tests {
     use super::*;
     use crate::rules;
-    use parity_wasm::{builder, elements, elements::Instruction::*, serialize};
+    use casper_wasm::{builder, elements, elements::Instruction::*, serialize};
 
     pub fn get_function_body(
         module: &elements::Module,

--- a/src/gas/validation.rs
+++ b/src/gas/validation.rs
@@ -13,7 +13,7 @@ use crate::{
     rules::{Rules, Set as RuleSet},
     std::vec::Vec,
 };
-use parity_wasm::elements::{FuncBody, Instruction};
+use casper_wasm::elements::{FuncBody, Instruction};
 
 use crate::std::collections::BTreeMap as Map;
 
@@ -343,7 +343,7 @@ mod tests {
     use super::{super::determine_metered_blocks, *};
 
     use binaryen::tools::translate_to_fuzz_mvp;
-    use parity_wasm::elements;
+    use casper_wasm::elements;
     use rand::{thread_rng, RngCore};
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,6 @@ mod symbols;
 
 pub mod stack_height;
 
-pub use casper_wasm;
 pub use ext::{
     externalize, externalize_mem, shrink_unknown_stack, underscore_funcs, ununderscore_funcs,
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,12 +15,12 @@ mod symbols;
 
 pub mod stack_height;
 
+pub use casper_wasm;
 pub use ext::{
     externalize, externalize_mem, shrink_unknown_stack, underscore_funcs, ununderscore_funcs,
 };
 pub use gas::inject_gas_counter;
 pub use optimizer::{optimize, Error as OptimizerError};
-pub use parity_wasm;
 
 pub struct TargetSymbols {
     pub create: &'static str,

--- a/src/optimizer.rs
+++ b/src/optimizer.rs
@@ -3,8 +3,8 @@ use crate::std::collections::BTreeSet as Set;
 use crate::std::{mem, vec::Vec};
 
 use crate::symbols::{expand_symbols, push_code_symbols, resolve_function, Symbol};
+use casper_wasm::elements;
 use log::trace;
-use parity_wasm::elements;
 
 #[derive(Debug)]
 pub enum Error {
@@ -426,7 +426,7 @@ pub fn optimize(
 }
 
 pub fn update_call_index(instructions: &mut elements::Instructions, eliminated_indices: &[usize]) {
-    use parity_wasm::elements::Instruction::*;
+    use casper_wasm::elements::Instruction::*;
     for instruction in instructions.elements_mut().iter_mut() {
         if let Call(call_index) = instruction {
             let totalle = eliminated_indices
@@ -448,7 +448,7 @@ pub fn update_global_index(
     instructions: &mut [elements::Instruction],
     eliminated_indices: &[usize],
 ) {
-    use parity_wasm::elements::Instruction::*;
+    use casper_wasm::elements::Instruction::*;
     for instruction in instructions.iter_mut() {
         match instruction {
             GetGlobal(index) | SetGlobal(index) => {
@@ -470,7 +470,7 @@ pub fn update_global_index(
 
 /// Updates global references considering the _ordered_ list of eliminated indices
 pub fn update_type_index(instructions: &mut elements::Instructions, eliminated_indices: &[usize]) {
-    use parity_wasm::elements::Instruction::*;
+    use casper_wasm::elements::Instruction::*;
     for instruction in instructions.elements_mut().iter_mut() {
         if let CallIndirect(call_index, _) = instruction {
             let totalle = eliminated_indices
@@ -545,7 +545,7 @@ pub fn type_section(module: &mut elements::Module) -> Option<&mut elements::Type
 mod tests {
 
     use super::*;
-    use parity_wasm::{builder, elements};
+    use casper_wasm::{builder, elements};
 
     /// @spec 0
     /// Optimizer presumes that export section exists and contains

--- a/src/optimizer.rs
+++ b/src/optimizer.rs
@@ -1,4 +1,3 @@
-#[cfg(not(features = "std"))]
 use crate::std::collections::BTreeSet as Set;
 use crate::std::{mem, vec::Vec};
 

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -1,7 +1,7 @@
 use crate::std::collections::BTreeMap as Map;
 
 use crate::std::{num::NonZeroU32, str::FromStr};
-use parity_wasm::elements::Instruction;
+use casper_wasm::elements::Instruction;
 
 pub struct UnknownInstruction;
 

--- a/src/stack_height.rs
+++ b/src/stack_height.rs
@@ -51,7 +51,7 @@
 
 use crate::std::{mem, string::String, vec::Vec};
 
-use parity_wasm::{
+use casper_wasm::{
     builder,
     elements::{self, Instruction, Instructions, Type},
 };
@@ -59,7 +59,7 @@ use parity_wasm::{
 /// Macro to generate preamble and postamble.
 macro_rules! instrument_call {
     ($callee_idx: expr, $callee_stack_cost: expr, $stack_height_global_idx: expr, $stack_limit: expr) => {{
-        use $crate::parity_wasm::elements::Instruction::*;
+        use $crate::casper_wasm::elements::Instruction::*;
         [
             // stack_height += stack_cost(F)
             GetGlobal($stack_height_global_idx),
@@ -365,7 +365,7 @@ fn resolve_func_type(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use parity_wasm::elements;
+    use casper_wasm::elements;
 
     fn parse_wat(source: &str) -> elements::Module {
         elements::deserialize_buffer(&wabt::wat2wasm(source).expect("Failed to wat2wasm"))

--- a/src/stack_height/max_height.rs
+++ b/src/stack_height/max_height.rs
@@ -1,11 +1,11 @@
 use crate::std::vec::Vec;
 
 use super::{resolve_func_type, Error};
+use casper_wasm::elements::{self, BlockType, Type};
 use log::trace;
-use parity_wasm::elements::{self, BlockType, Type};
 
 #[cfg(feature = "sign_ext")]
-use parity_wasm::elements::SignExtInstruction;
+use casper_wasm::elements::SignExtInstruction;
 
 /// Control stack frame.
 #[derive(Debug)]
@@ -143,7 +143,7 @@ impl Stack {
 
 /// This function expects the function to be validated.
 pub(crate) fn compute(func_idx: u32, module: &elements::Module) -> Result<u32, Error> {
-    use parity_wasm::elements::Instruction::*;
+    use casper_wasm::elements::Instruction::*;
 
     let func_section = module
         .function_section()
@@ -443,7 +443,7 @@ pub(crate) fn compute(func_idx: u32, module: &elements::Module) -> Result<u32, E
 #[cfg(test)]
 mod tests {
     use super::*;
-    use parity_wasm::elements;
+    use casper_wasm::elements;
 
     fn parse_wat(source: &str) -> elements::Module {
         elements::deserialize_buffer(&wabt::wat2wasm(source).expect("Failed to wat2wasm"))

--- a/src/stack_height/thunk.rs
+++ b/src/stack_height/thunk.rs
@@ -1,7 +1,7 @@
 use crate::std::collections::{BTreeMap as Map, BTreeSet as Set};
 use crate::std::vec::Vec;
 
-use parity_wasm::{
+use casper_wasm::{
     builder,
     elements::{self, FunctionType, Internal},
 };

--- a/src/stack_height/thunk.rs
+++ b/src/stack_height/thunk.rs
@@ -6,7 +6,7 @@ use casper_wasm::{
     elements::{self, FunctionType, Internal},
 };
 
-use super::{resolve_func_type, Context, Error};
+use super::{instrument_call, resolve_func_type, Context, Error};
 
 struct Thunk {
     signature: FunctionType,
@@ -77,11 +77,11 @@ pub(crate) fn generate_thunks(
 
     let mut mbuilder = builder::from_module(module);
     for (func_idx, thunk) in replacement_map.iter_mut() {
-        let instrumented_call = instrument_call!(
+        let instrumented_call = instrument_call(
             *func_idx,
-            thunk.callee_stack_cost as i32,
+            thunk.callee_stack_cost,
             ctx.stack_height_global_idx(),
-            ctx.stack_limit()
+            ctx.stack_limit(),
         );
         // Thunk body consist of:
         //  - argument pushing

--- a/src/symbols.rs
+++ b/src/symbols.rs
@@ -1,8 +1,8 @@
 use crate::std::collections::BTreeSet as Set;
 use crate::std::vec::Vec;
 
+use casper_wasm::elements;
 use log::trace;
-use parity_wasm::elements;
 
 #[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Copy, Clone, Debug)]
 pub enum Symbol {
@@ -50,7 +50,7 @@ pub fn push_code_symbols(
     instructions: &[elements::Instruction],
     dest: &mut Vec<Symbol>,
 ) {
-    use parity_wasm::elements::Instruction::*;
+    use casper_wasm::elements::Instruction::*;
 
     for instruction in instructions {
         match instruction {

--- a/tests/diff.rs
+++ b/tests/diff.rs
@@ -1,5 +1,5 @@
+use casper_wasm::elements;
 use casper_wasm_utils as utils;
-use parity_wasm::elements;
 
 use std::{
     fs,


### PR DESCRIPTION
- Use the `casper-wasm` crate instead of `parity-wasm`
- Do not re-export `casper-wasm` anymore to avoid further major releases.